### PR TITLE
[refactor/#9] 현재 달의 이전 요일 채우기

### DIFF
--- a/Pungdeong/Pungdeong/Domain/Calendar/Entity/CalendarDay.swift
+++ b/Pungdeong/Pungdeong/Domain/Calendar/Entity/CalendarDay.swift
@@ -16,10 +16,8 @@ struct CalendarDay: Identifiable, Equatable {
     let isSaturday: Bool
     let isSelected: Bool
     let level: PungdeongLevel?
-
-    var isPlaceholder: Bool {
-        number == nil || date == nil
-    }
+    let isPlaceholder: Bool
+    let isFiller: Bool
 
     var progress: Double {
         level?.progress ?? 0

--- a/Pungdeong/Pungdeong/Domain/Calendar/UseCase/GetCalendarDaysUseCase.swift
+++ b/Pungdeong/Pungdeong/Domain/Calendar/UseCase/GetCalendarDaysUseCase.swift
@@ -18,11 +18,12 @@ protocol GetCalendarDaysUseCase {
 
 final class DefaultGetCalendarDaysUseCase: GetCalendarDaysUseCase {
     private let repository: CalendarRepository
-    
+    private let calendar = Calendar.current
+
     init(repository: CalendarRepository) {
         self.repository = repository
     }
-    
+
     func execute(
         baseDate: Date,
         offset: Int,
@@ -31,56 +32,99 @@ final class DefaultGetCalendarDaysUseCase: GetCalendarDaysUseCase {
     ) -> [CalendarDay] {
         let monthDate = repository.makeMonthDate(from: baseDate, offset: offset)
         let dates = repository.fetchMonthDates(for: monthDate)
-        
-        guard let firstDate = dates.first else { return [] }
-        
+
+        guard
+            let firstDate = dates.first,
+            let lastDate = dates.last
+        else {
+            return []
+        }
+
+        let normalizedSelectedDate = selectedDate.map { calendar.startOfDay(for: $0) }
+
         let firstWeekday = repository.firstWeekday(for: firstDate)
         let placeholderCount = max(0, firstWeekday - 1)
-        
-        let placeholders = Array(
-            repeating: CalendarDay(
-                number: nil,
-                date: nil,
-                isToday: false,
-                isSunday: false,
-                isSaturday: false,
-                isSelected: false,
-                level: nil
-            ),
-            count: placeholderCount
-        )
-        
-        let realDays = dates.map { date in
+
+        let leadingPlaceholders: [CalendarDay] = (0..<placeholderCount).compactMap { index in
+            let daysToSubtract = placeholderCount - index
+
+            guard let rawDate = calendar.date(byAdding: .day, value: -daysToSubtract, to: firstDate) else {
+                return nil
+            }
+
+            let date = calendar.startOfDay(for: rawDate)
             let weekday = repository.weekday(for: date)
-            
+
             return CalendarDay(
                 number: repository.dayNumber(for: date),
                 date: date,
                 isToday: repository.isToday(date),
                 isSunday: weekday == 1,
                 isSaturday: weekday == 7,
-                isSelected: selectedDate.map { repository.isSameDay($0, date) } ?? false,
-                level: levelProvider(date)
+                isSelected: normalizedSelectedDate.map { repository.isSameDay($0, date) } ?? false,
+                level: nil,
+                isPlaceholder: true,
+                isFiller: false
             )
         }
-        
-        var calendarDays = placeholders + realDays
-        
-        while calendarDays.count < 42 {
-            calendarDays.append(
-                CalendarDay(
-                    number: nil,
-                    date: nil,
-                    isToday: false,
-                    isSunday: false,
-                    isSaturday: false,
-                    isSelected: false,
-                    level: nil
-                )
+
+        let realDays: [CalendarDay] = dates.map { rawDate in
+            let date = calendar.startOfDay(for: rawDate)
+            let weekday = repository.weekday(for: date)
+
+            return CalendarDay(
+                number: repository.dayNumber(for: date),
+                date: date,
+                isToday: repository.isToday(date),
+                isSunday: weekday == 1,
+                isSaturday: weekday == 7,
+                isSelected: normalizedSelectedDate.map { repository.isSameDay($0, date) } ?? false,
+                level: levelProvider(date),
+                isPlaceholder: false,
+                isFiller: false
             )
         }
-        
-        return calendarDays
+
+        let currentCount = leadingPlaceholders.count + realDays.count
+        let visibleTrailingCount = currentCount % 7 == 0 ? 0 : 7 - (currentCount % 7)
+
+        let trailingPlaceholders: [CalendarDay] = (0..<visibleTrailingCount).compactMap { index in
+            guard let rawDate = calendar.date(byAdding: .day, value: index + 1, to: lastDate) else {
+                return nil
+            }
+
+            let date = calendar.startOfDay(for: rawDate)
+            let weekday = repository.weekday(for: date)
+
+            return CalendarDay(
+                number: repository.dayNumber(for: date),
+                date: date,
+                isToday: repository.isToday(date),
+                isSunday: weekday == 1,
+                isSaturday: weekday == 7,
+                isSelected: normalizedSelectedDate.map { repository.isSameDay($0, date) } ?? false,
+                level: nil,
+                isPlaceholder: true,
+                isFiller: false
+            )
+        }
+
+        let fillerCount = max(0, 42 - (currentCount + trailingPlaceholders.count))
+
+        let fillers: [CalendarDay] = (0..<fillerCount).map { _ in
+            CalendarDay(
+                number: nil,
+                date: nil,
+                isToday: false,
+                isSunday: false,
+                isSaturday: false,
+                isSelected: false,
+                level: nil,
+                isPlaceholder: false,
+                isFiller: true
+            )
+        }
+
+        return leadingPlaceholders + realDays + trailingPlaceholders + fillers
     }
 }
-

--- a/Pungdeong/Pungdeong/Domain/Record/UseCase/GetDayRecordsUseCase.swift
+++ b/Pungdeong/Pungdeong/Domain/Record/UseCase/GetDayRecordsUseCase.swift
@@ -11,15 +11,13 @@ protocol GetDayRecordsUseCase {
     func execute(baseDate: Date) -> [DailyRecord]
 }
 
-
 final class DefaultGetDayRecordUseCase: GetDayRecordsUseCase {
     private let calendar = Calendar.current
     
     func execute(baseDate: Date) -> [DailyRecord] {
         let today = calendar.startOfDay(for: baseDate)
         let yesterday = calendar.date(byAdding: .day, value: -1, to: today) ?? today
-        let beforeYesterday = calendar.date(byAdding: .day, value: 1, to: today) ?? today
-        
+        let beforeYesterday = calendar.date(byAdding: .day, value: -2, to: today) ?? today
         
         return [
             DailyRecord(date: beforeYesterday),

--- a/Pungdeong/Pungdeong/Presentation/Calendar/CalendarView.swift
+++ b/Pungdeong/Pungdeong/Presentation/Calendar/CalendarView.swift
@@ -38,7 +38,6 @@ struct CalendarView: View {
                 onTapDate: viewModel.select
             )
             .frame(maxWidth: .infinity)
-            .frame(height: 500)
         }
         .padding(.horizontal, 20)
         .padding(.top, 16)
@@ -49,6 +48,7 @@ struct CalendarView: View {
                         .fill(.clear)
                         .contentShape(Rectangle())
                         .ignoresSafeArea()
+                     
                         .onTapGesture {
                             viewModel.closeMonthPicker()
                         }
@@ -73,21 +73,5 @@ struct CalendarView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
     }
-}
-
-#Preview {
-    let repository = DefaultCalendarRepository()
-    
-    let viewModel = CalendarViewModel(
-        getCalendarDaysUseCase: DefaultGetCalendarDaysUseCase(
-            repository: repository
-        ),
-        moveMonthUseCase: DefaultMoveMonthUseCase(),
-        formatCalendarHeaderUseCase: DefaultFormatCalendarHeaderUseCase(
-            repository: repository
-        )
-    )
-    
-    return CalendarView(viewModel: viewModel)
 }
 

--- a/Pungdeong/Pungdeong/Presentation/Calendar/Component/CalendarDateCellView.swift
+++ b/Pungdeong/Pungdeong/Presentation/Calendar/Component/CalendarDateCellView.swift
@@ -49,7 +49,7 @@ struct CalendarDateCellView: View {
     }
 
     private var textColor: Color {
-        if day.isPlaceholder { return .clear }
+        if day.isPlaceholder { return .gray }
         if day.isSunday { return .red }
         if day.isSaturday { return .blue }
         return .black


### PR DESCRIPTION
## ☀️ 작업 내용
- `leadingPlaceholders`, `trailingPlaceholders`, `fillers` 생성

|    구현 내용    |   iPhone 17   | 
| :-------------: | :----------: | 
| 빈 날짜 <br> 회색으로 채우기 | <img src = "https://github.com/user-attachments/assets/1c376746-1fbb-4b2b-9d5b-6d63f8658290" width ="250"> | 

## 🌤️ 주요 코드 설명
### 뒤쪽 placeholder (다음 달 날짜 채우기)
```Swift
let visibleTrailingCount = currentCount % 7 == 0 ? 0 : 7 - (currentCount % 7)
```
한 줄(7칸)이 안 맞으면 → 다음 달 날짜로 채움

### filler (완전 빈 칸)
```Swift
let fillerCount = max(0, 42 - (currentCount + trailingPlaceholders.count))
```
- 달력 UI는 보통 6줄(= 42칸) 고정
- 부족하면 아무것도 없는 셀 추가

`isFiller`가 UI 맞추려고 넣은 완전 빈 칸이라고 보시면 됩니닷!!!

### 전체 구조
> 이전달 채우기 + 현재달 실제 날짜 + 다음달 채우기+ 빈칸 filler

## 🌦️ 기타 더 이야기해볼 점
잭키 코드 조아보여서 그걸로 리팩할까 햇는데...? 그 코드는 `isEmpty` 하나로만 빈 칸을 처리하니까  이전 달 날짜를 보여주는 칸인지, 다음 달 날짜인지, 아무것도 없는 게 맞는 건지... 이걸 정하기가 어렵더라구여?ㅜㅠ 그래서 역할에 따라 4가지로 나눴어요

사실 코드가 길어져서 고민을 했는데 의미가 명확해져서 더 나은 것 같기도...?🧐 더 멘토들이랑 이야기해보겟슴니듀